### PR TITLE
Add remaining screens

### DIFF
--- a/core/src/main/kotlin/no/ntnu/beardblaster/AbstractScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/AbstractScreen.kt
@@ -6,14 +6,14 @@ import ktx.app.KtxScreen
 abstract class AbstractScreen(
         val game: BeardBlasterGame,
         val batch: Batch = game.batch
-        )
-    : KtxScreen {
+) : KtxScreen {
     val cam = game.cam
     val viewport = game.viewport
 
     override fun show() {
 
     }
+
     abstract fun update(delta: Float)
 
 

--- a/core/src/main/kotlin/no/ntnu/beardblaster/BeardBlasterGame.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/BeardBlasterGame.kt
@@ -16,9 +16,10 @@ private val LOG = logger<BeardBlasterGame>()
 const val worldWidth = 1920f
 const val worldHeight = 1080f
 
-//Gameclass that extends KTX game with an abstract screen
+// Game class that extends KTX game with an abstract screen
 class BeardBlasterGame : KtxGame<AbstractScreen>() {
-    val batch : Batch by lazy { SpriteBatch() }
+    val batch: Batch by lazy { SpriteBatch() }
+
     /*val stage: Stage by lazy {
         val result = Stage(FitViewport(worldWidth, worldHeight))
         Gdx.input.inputProcessor = result
@@ -31,15 +32,24 @@ class BeardBlasterGame : KtxGame<AbstractScreen>() {
         //Set debug level
         Gdx.app.logLevel = Application.LOG_DEBUG
         LOG.debug { "Create game instance" }
+        // Speed login
+        // if (!UserAuth().isLoggedIn()) {
+        //    UserAuth().signIn("beard@blaster.com", "beardblaster")
+        //}
         initScreens()
+
     }
-    //Add all screens and set loading screen
+
+    // Add all screens and set loading screen
     fun initScreens() {
         addScreen(LoadingScreen(this))
         addScreen(LoginMenuScreen(this))
         addScreen(LoginScreen(this))
         addScreen(RegisterScreen(this))
         addScreen(MenuScreen(this))
+        addScreen(CreateLobbyScreen(this))
+        addScreen(JoinLobbyScreen(this))
+        addScreen(GameplayScreen(this))
 
         setScreen<LoadingScreen>()
     }

--- a/core/src/main/kotlin/no/ntnu/beardblaster/BeardBlasterGame.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/BeardBlasterGame.kt
@@ -19,35 +19,26 @@ const val worldHeight = 1080f
 // Game class that extends KTX game with an abstract screen
 class BeardBlasterGame : KtxGame<AbstractScreen>() {
     val batch: Batch by lazy { SpriteBatch() }
-
-    /*val stage: Stage by lazy {
-        val result = Stage(FitViewport(worldWidth, worldHeight))
-        Gdx.input.inputProcessor = result
-        result
-    }*/
     val cam: OrthographicCamera = OrthographicCamera()
     val viewport: FitViewport = FitViewport(worldWidth, worldHeight, cam)
 
     override fun create() {
-        //Set debug level
+        // Set debug level
         Gdx.app.logLevel = Application.LOG_DEBUG
         LOG.debug { "Create game instance" }
-        // Speed login
-        // if (!UserAuth().isLoggedIn()) {
-        //    UserAuth().signIn("beard@blaster.com", "beardblaster")
-        //}
         initScreens()
-
     }
 
     // Add all screens and set loading screen
-    fun initScreens() {
+    private fun initScreens() {
         addScreen(LoadingScreen(this))
         addScreen(LoginMenuScreen(this))
         addScreen(LoginScreen(this))
         addScreen(RegisterScreen(this))
         addScreen(MenuScreen(this))
-        addScreen(CreateLobbyScreen(this))
+        addScreen(TutorialScreen(this))
+        addScreen(HighscoreScreen(this))
+        addScreen(LobbyScreen(this))
         addScreen(JoinLobbyScreen(this))
         addScreen(GameplayScreen(this))
 

--- a/core/src/main/kotlin/no/ntnu/beardblaster/assets/Assets.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/assets/Assets.kt
@@ -9,7 +9,7 @@ import com.badlogic.gdx.graphics.g2d.TextureAtlas
 
 object Assets {
 
-    //Define all assets that must be loaded during loading screen
+    // Define all assets that must be loaded during loading screen
     var assetManager = AssetManager()
     val loadBar = AssetDescriptor<Texture>("graphics/load_bar.png", Texture::class.java)
     val loginImg = AssetDescriptor<Texture>("graphics/login.png", Texture::class.java)
@@ -21,11 +21,11 @@ object Assets {
     val test6 = AssetDescriptor<Texture>("button_default.png", Texture::class.java)
     val atlas = AssetDescriptor<TextureAtlas>("bb_gui.atlas", TextureAtlas::class.java)
 
-    //fonts
-    val standardFont =  AssetDescriptor<BitmapFont>("font_nevis/nevis.fnt", BitmapFont::class.java)
+    // Fonts
+    val standardFont = AssetDescriptor<BitmapFont>("font_nevis/nevis.fnt", BitmapFont::class.java)
 
 
-    //Load all assets
+    // Load all assets
     fun loadTextures() {
         assetManager.load(loadBar)
         assetManager.load(loginImg)
@@ -37,8 +37,8 @@ object Assets {
         assetManager.load(test6)
         assetManager.load(atlas)
         assetManager.load(standardFont)
-
     }
+
     fun dispose() {
         assetManager.dispose()
     }

--- a/core/src/main/kotlin/no/ntnu/beardblaster/user/UserAuth.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/user/UserAuth.kt
@@ -39,9 +39,7 @@ class UserAuth : IUserAuth {
                     LOG.debug { "Signed in. currentUser: ${GdxFIRAuth.inst().currentUser?.userInfo?.email}" }
                 }
                 .fail { s, _ ->
-                    if (s.contains("")) {
-                        LOG.debug { "No user exists with those credentials: ($email, $password) - $s" }
-                    }
+                    LOG.debug { "Login failed: $s" }
                 }
     }
 
@@ -51,9 +49,7 @@ class UserAuth : IUserAuth {
                     LOG.debug { "Signed out. currentUser: ${GdxFIRAuth.inst().currentUser}" }
                 }
                 .fail { s, _ ->
-                    if (s.contains("")) {
-                        LOG.debug { "Already logged out $s" }
-                    }
+                    LOG.debug { "Already logged out $s" }
                 }
     }
 

--- a/core/src/main/kotlin/no/ntnu/beardblaster/user/UserAuth.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/user/UserAuth.kt
@@ -1,8 +1,8 @@
-package no.ntnu.beardblaster
+package no.ntnu.beardblaster.user
 
-import com.badlogic.gdx.Gdx
-import no.ntnu.beardblaster.commons.User
-import no.ntnu.beardblaster.firestore.Firestore
+import ktx.log.debug
+import ktx.log.error
+import ktx.log.logger
 import pl.mk5.gdx.fireapp.GdxFIRAuth
 import pl.mk5.gdx.fireapp.auth.GdxFirebaseUser
 
@@ -10,7 +10,10 @@ interface IUserAuth {
     fun createUser(email: String, password: String, displayName: String)
     fun signIn(email: String, password: String)
     fun signOut()
+    fun isLoggedIn(): Boolean
 }
+
+private val LOG = logger<UserAuth>()
 
 class UserAuth : IUserAuth {
 
@@ -18,19 +21,14 @@ class UserAuth : IUserAuth {
         GdxFIRAuth.inst()
                 .createUserWithEmailAndPassword(email, password.toCharArray())
                 .then<GdxFirebaseUser> {
-                    Gdx.app.debug("Create user", "Created user: ${GdxFIRAuth.inst().currentUser?.userInfo?.email}")
-                    val newUser = User(displayName, id = GdxFIRAuth.inst().currentUser.userInfo.uid)
-                    Firestore<User>().create(newUser, "users")
-
-                  // TODO: This should not throw an exception!
-                  //  val usr = Firestore<User>().getDocument(GdxFIRAuth.inst().currentUser.userInfo.uid, "users")
-                  //  Gdx.app.debug("Create user", "Found user: ${usr?.displayName}")
+                    LOG.debug { "Created user: $displayName, ${GdxFIRAuth.inst().currentUser?.userInfo?.email}" }
+                    // TODO: Add user to /users/${GdxFIRAuth.inst().currentUser?.userInfo?.uid} with displayName and beardLength = 0
                 }
                 .fail { s, _ ->
                     if (s.contains("The email address is already in use by another account")) {
-                        Gdx.app.debug("Create user", "Tried to create a duplicate user")
+                        LOG.debug { "Tried to create a duplicate user $email" }
                     }
-                    Gdx.app.error("Create user failed", s)
+                    LOG.error { "Create user failed $s" }
                 }
     }
 
@@ -38,11 +36,11 @@ class UserAuth : IUserAuth {
         GdxFIRAuth.inst()
                 .signInWithEmailAndPassword(email, password.toCharArray())
                 .then<GdxFirebaseUser> { gdxFirebaseUser ->
-                    Gdx.app.debug("Sign in user", "Signed in. currentUser: " + GdxFIRAuth.inst().currentUser?.userInfo?.email)
+                    LOG.debug { "Signed in. currentUser: ${GdxFIRAuth.inst().currentUser?.userInfo?.email}" }
                 }
                 .fail { s, _ ->
                     if (s.contains("")) {
-                        Gdx.app.debug("Sign in user", "No user exists with those credentials" + s)
+                        LOG.debug { "No user exists with those credentials: ($email, $password) - $s" }
                     }
                 }
     }
@@ -50,12 +48,17 @@ class UserAuth : IUserAuth {
     override fun signOut() {
         GdxFIRAuth.inst().signOut()
                 .then<Void> {
-                    Gdx.app.debug("Sign out user", "Signed out. currentUser: " + GdxFIRAuth.inst().currentUser)
+                    LOG.debug { "Signed out. currentUser: ${GdxFIRAuth.inst().currentUser}" }
                 }
                 .fail { s, _ ->
                     if (s.contains("")) {
-                        Gdx.app.debug("Sign out user", "Already logged out" + s)
+                        LOG.debug { "Already logged out $s" }
                     }
                 }
+    }
+
+    override fun isLoggedIn(): Boolean {
+        LOG.debug { "Check current user: ${GdxFIRAuth.inst().currentUser?.userInfo?.email}" }
+        return GdxFIRAuth.inst().currentUser !== null
     }
 }

--- a/core/src/main/kotlin/no/ntnu/beardblaster/view/CreateLobbyScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/view/CreateLobbyScreen.kt
@@ -1,0 +1,102 @@
+package no.ntnu.beardblaster.view
+
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.graphics.GL20
+import com.badlogic.gdx.scenes.scene2d.Stage
+import com.badlogic.gdx.scenes.scene2d.ui.Label
+import com.badlogic.gdx.scenes.scene2d.ui.Skin
+import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton
+import com.badlogic.gdx.utils.Align
+import com.badlogic.gdx.utils.viewport.FitViewport
+import ktx.actors.onClick
+import ktx.log.debug
+import ktx.log.logger
+import no.ntnu.beardblaster.AbstractScreen
+import no.ntnu.beardblaster.BeardBlasterGame
+import no.ntnu.beardblaster.assets.Assets
+import no.ntnu.beardblaster.worldHeight
+import no.ntnu.beardblaster.worldWidth
+
+
+private val LOG = logger<CreateLobbyScreen>()
+
+
+class CreateLobbyScreen(game: BeardBlasterGame) : AbstractScreen(game) {
+    private lateinit var skin: Skin
+    private lateinit var table: Table
+    private lateinit var heading: Label
+
+    private lateinit var btnStartGame: TextButton
+    private lateinit var btnBack: TextButton
+
+    private val createLobbyStage: Stage by lazy {
+        val result = Stage(FitViewport(worldWidth, worldHeight))
+        Gdx.input.inputProcessor = result
+        result
+    }
+
+    override fun show() {
+        LOG.debug { "CREATE LOBBY Screen" }
+
+        skin = Skin(Assets.assetManager.get(Assets.atlas))
+        table = Table(skin)
+        table.setBounds(0f, 0f, viewport.worldWidth, viewport.worldHeight)
+
+        // Fonts
+        val standardFont = Assets.assetManager.get(Assets.standardFont)
+
+        // Creating buttons
+        val textButtonStyle = TextButton.TextButtonStyle()
+        skin.getDrawable("button_default").also { textButtonStyle.up = it }
+        skin.getDrawable("button_default_hover").also { textButtonStyle.over = it }
+        skin.getDrawable("button_default_pressed").also { textButtonStyle.down = it }
+        textButtonStyle.pressedOffsetX = 4f
+        textButtonStyle.pressedOffsetY = -4f
+        textButtonStyle.font = standardFont
+
+        btnStartGame = TextButton("START GAME", textButtonStyle)
+        btnBack = TextButton("GO BACK", textButtonStyle)
+
+        // Creating heading
+        Label.LabelStyle(standardFont, Color.BLACK).also {
+            heading = Label("CREATE LOBBY", it)
+            heading.setFontScale(2f)
+            it.background = skin.getDrawable("modal_fancy_header")
+            heading.setAlignment(Align.center)
+        }
+
+        // Creating table
+        table.background = skin.getDrawable("modal_fancy")
+        table.add(heading).pad(50f)
+        table.row()
+        table.add(btnStartGame).pad(40f)
+        table.row()
+        table.add(btnBack).pad(40f)
+        table.row()
+
+        // Adding actors to the stage
+        createLobbyStage.addActor(table)
+    }
+
+    override fun update(delta: Float) {
+        btnStartGame.onClick {
+            game.setScreen<GameplayScreen>()
+        }
+        btnBack.onClick {
+            game.setScreen<MenuScreen>()
+        }
+    }
+
+    override fun render(delta: Float) {
+        Gdx.gl.glClearColor(0f, 0f, 0f, 1f)
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT)
+        update(delta)
+
+        createLobbyStage.act(delta)
+        createLobbyStage.draw()
+    }
+
+
+}

--- a/core/src/main/kotlin/no/ntnu/beardblaster/view/GameplayScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/view/GameplayScreen.kt
@@ -1,0 +1,103 @@
+package no.ntnu.beardblaster.view
+
+import com.badlogic.gdx.Game
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.graphics.GL20
+import com.badlogic.gdx.scenes.scene2d.Stage
+import com.badlogic.gdx.scenes.scene2d.ui.Label
+import com.badlogic.gdx.scenes.scene2d.ui.Skin
+import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton
+import com.badlogic.gdx.utils.Align
+import com.badlogic.gdx.utils.viewport.FitViewport
+import ktx.actors.onClick
+import ktx.log.debug
+import ktx.log.logger
+import no.ntnu.beardblaster.AbstractScreen
+import no.ntnu.beardblaster.BeardBlasterGame
+import no.ntnu.beardblaster.assets.Assets
+import no.ntnu.beardblaster.worldHeight
+import no.ntnu.beardblaster.worldWidth
+
+
+private val LOG = logger<GameplayScreen>()
+
+
+class GameplayScreen(game: BeardBlasterGame) : AbstractScreen(game) {
+    private lateinit var skin: Skin
+    private lateinit var table: Table
+    private lateinit var heading: Label
+
+    private lateinit var btnAttack: TextButton
+    private lateinit var btnQuit: TextButton
+
+    private val gameplayStage: Stage by lazy {
+        val result = Stage(FitViewport(worldWidth, worldHeight))
+        Gdx.input.inputProcessor = result
+        result
+    }
+
+    override fun show() {
+        LOG.debug { "GAMEPLAY Screen" }
+
+        skin = Skin(Assets.assetManager.get(Assets.atlas))
+        table = Table(skin)
+        table.setBounds(0f, 0f, viewport.worldWidth, viewport.worldHeight)
+
+        // Fonts
+        val standardFont = Assets.assetManager.get(Assets.standardFont)
+
+        // Creating buttons
+        val textButtonStyle = TextButton.TextButtonStyle()
+        skin.getDrawable("button_default").also { textButtonStyle.up = it }
+        skin.getDrawable("button_default_hover").also { textButtonStyle.over = it }
+        skin.getDrawable("button_default_pressed").also { textButtonStyle.down = it }
+        textButtonStyle.pressedOffsetX = 4f
+        textButtonStyle.pressedOffsetY = -4f
+        textButtonStyle.font = standardFont
+
+        btnAttack = TextButton("ATTACK", textButtonStyle)
+        btnQuit = TextButton("QUIT", textButtonStyle)
+
+        Label.LabelStyle(standardFont, Color.BLACK).also {
+            heading = Label("Preparation phase", it)
+            heading.setFontScale(2f)
+            it.background = skin.getDrawable("modal_fancy_header")
+            heading.setAlignment(Align.center)
+        }
+
+        // Creating table
+        table.add(heading).pad(50f)
+        table.row()
+        table.add(btnAttack).pad(40f)
+        table.row()
+        table.add(btnQuit).pad(40f)
+        table.row()
+
+        // Adding actors to the stage
+        gameplayStage.addActor(table)
+    }
+
+    override fun update(delta: Float) {
+        btnAttack.onClick {
+            LOG.debug { "Wizard 1 attacks" }
+        }
+        btnQuit.onClick {
+            game.removeScreen<GameplayScreen>()
+            game.addScreen(GameplayScreen(game))
+            game.setScreen<MenuScreen>()
+        }
+    }
+
+    override fun render(delta: Float) {
+        Gdx.gl.glClearColor(0f, 0f, 0f, 1f)
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT)
+        update(delta)
+
+        gameplayStage.act(delta)
+        gameplayStage.draw()
+    }
+
+
+}

--- a/core/src/main/kotlin/no/ntnu/beardblaster/view/HighscoreScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/view/HighscoreScreen.kt
@@ -20,73 +20,64 @@ import no.ntnu.beardblaster.worldHeight
 import no.ntnu.beardblaster.worldWidth
 
 
-private val LOG = logger<GameplayScreen>()
+private val LOG = logger<HighscoreScreen>()
 
 
-class GameplayScreen(game: BeardBlasterGame) : AbstractScreen(game) {
+class HighscoreScreen(game: BeardBlasterGame) : AbstractScreen(game) {
     private lateinit var skin: Skin
     private lateinit var table: Table
     private lateinit var heading: Label
 
-    private lateinit var btnAttack: TextButton
-    private lateinit var btnQuit: TextButton
+    private lateinit var closeBtn: TextButton
 
-    private val gameplayStage: Stage by lazy {
+    private val highscoreStage: Stage by lazy {
         val result = Stage(FitViewport(worldWidth, worldHeight))
         Gdx.input.inputProcessor = result
         result
     }
-
+    
     override fun show() {
-        LOG.debug { "GAMEPLAY Screen" }
+        LOG.debug { "HIGHSCORE Screen" }
 
         skin = Skin(Assets.assetManager.get(Assets.atlas))
         table = Table(skin)
         table.setBounds(0f, 0f, viewport.worldWidth, viewport.worldHeight)
 
-        // Fonts
         val standardFont = Assets.assetManager.get(Assets.standardFont)
 
-        // Creating buttons
-        val textButtonStyle = TextButton.TextButtonStyle()
-        skin.getDrawable("button_default").also { textButtonStyle.up = it }
-        skin.getDrawable("button_default_hover").also { textButtonStyle.over = it }
-        skin.getDrawable("button_default_pressed").also { textButtonStyle.down = it }
-        textButtonStyle.pressedOffsetX = 4f
-        textButtonStyle.pressedOffsetY = -4f
-        textButtonStyle.font = standardFont
-
-        btnAttack = TextButton("ATTACK", textButtonStyle)
-        btnQuit = TextButton("QUIT", textButtonStyle)
-
         Label.LabelStyle(standardFont, Color.BLACK).also {
-            heading = Label("Preparation phase", it)
+            heading = Label("Leaderbeard", it)
             heading.setFontScale(2f)
             it.background = skin.getDrawable("modal_fancy_header")
             heading.setAlignment(Align.center)
         }
 
+        val buttonStyle = TextButton.TextButtonStyle()
+        skin.getDrawable("button_default_pressed").also { buttonStyle.down = it }
+        skin.getDrawable("button_default").also { buttonStyle.up = it }
+        standardFont.apply {
+            buttonStyle.font = this
+        }
+
+        closeBtn = TextButton("CLOSE", buttonStyle)
+
         // Creating table
-        table.add(heading).pad(50f)
-        table.row()
-        table.add(btnAttack).pad(40f)
-        table.row()
-        table.add(btnQuit).pad(40f)
-        table.row()
+        table.apply {
+            this.defaults().pad(30f)
+            this.background = skin.getDrawable("background")
+            this.add(heading)
+            this.row()
+            this.add(closeBtn)
+        }
 
         // Adding actors to the stage
-        gameplayStage.addActor(table)
-        Gdx.input.inputProcessor = gameplayStage
+        highscoreStage.addActor(table)
 
+        Gdx.input.inputProcessor = highscoreStage
     }
 
     override fun update(delta: Float) {
-        btnAttack.onClick {
-            LOG.debug { "Wizard 1 attacks" }
-        }
-        btnQuit.onClick {
-            game.removeScreen<GameplayScreen>()
-            game.addScreen(GameplayScreen(game))
+        closeBtn.onClick {
             game.setScreen<MenuScreen>()
         }
     }
@@ -96,9 +87,7 @@ class GameplayScreen(game: BeardBlasterGame) : AbstractScreen(game) {
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT)
         update(delta)
 
-        gameplayStage.act(delta)
-        gameplayStage.draw()
+        highscoreStage.act(delta)
+        highscoreStage.draw()
     }
-
-
 }

--- a/core/src/main/kotlin/no/ntnu/beardblaster/view/JoinLobbyScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/view/JoinLobbyScreen.kt
@@ -1,0 +1,100 @@
+package no.ntnu.beardblaster.view
+
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.graphics.GL20
+import com.badlogic.gdx.scenes.scene2d.Stage
+import com.badlogic.gdx.scenes.scene2d.ui.Label
+import com.badlogic.gdx.scenes.scene2d.ui.Skin
+import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton
+import com.badlogic.gdx.utils.Align
+import com.badlogic.gdx.utils.viewport.FitViewport
+import ktx.actors.onClick
+import ktx.log.debug
+import ktx.log.logger
+import no.ntnu.beardblaster.AbstractScreen
+import no.ntnu.beardblaster.BeardBlasterGame
+import no.ntnu.beardblaster.assets.Assets
+import no.ntnu.beardblaster.worldHeight
+import no.ntnu.beardblaster.worldWidth
+
+private val LOG = logger<JoinLobbyScreen>()
+
+class JoinLobbyScreen(game: BeardBlasterGame) : AbstractScreen(game) {
+    private lateinit var skin: Skin
+    private lateinit var table: Table
+    private lateinit var heading: Label
+
+    private lateinit var btnStartGame: TextButton
+    private lateinit var btnBack: TextButton
+
+    private val joinLobbyStage: Stage by lazy {
+        val result = Stage(FitViewport(worldWidth, worldHeight))
+        Gdx.input.inputProcessor = result
+        result
+    }
+
+    override fun show() {
+        LOG.debug { "JOIN LOBBY Screen" }
+
+        skin = Skin(Assets.assetManager.get(Assets.atlas))
+        table = Table(skin)
+        table.setBounds(0f, 0f, viewport.worldWidth, viewport.worldHeight)
+
+        // Fonts
+        val standardFont = Assets.assetManager.get(Assets.standardFont)
+
+        // Creating buttons
+        val textButtonStyle = TextButton.TextButtonStyle()
+        skin.getDrawable("button_default").also { textButtonStyle.up = it }
+        skin.getDrawable("button_default_hover").also { textButtonStyle.over = it }
+        skin.getDrawable("button_default_pressed").also { textButtonStyle.down = it }
+        textButtonStyle.pressedOffsetX = 4f
+        textButtonStyle.pressedOffsetY = -4f
+        textButtonStyle.font = standardFont
+
+        btnStartGame = TextButton("START GAME", textButtonStyle)
+        btnBack = TextButton("GO BACK", textButtonStyle)
+
+        // Creating heading
+        Label.LabelStyle(standardFont, Color.BLACK).also {
+            heading = Label("JOIN LOBBY", it)
+            heading.setFontScale(2f)
+            it.background = skin.getDrawable("modal_fancy_header")
+            heading.setAlignment(Align.center)
+        }
+
+        // Creating table
+        table.background = skin.getDrawable("modal_fancy")
+        table.add(heading).pad(50f)
+        table.row()
+        table.add(btnStartGame).pad(40f)
+        table.row()
+        table.add(btnBack).pad(40f)
+        table.row()
+
+        // Adding actors to the stage
+        joinLobbyStage.addActor(table)
+    }
+
+    override fun update(delta: Float) {
+        btnStartGame.onClick {
+            game.setScreen<GameplayScreen>()
+        }
+        btnBack.onClick {
+            game.setScreen<MenuScreen>()
+        }
+    }
+
+    override fun render(delta: Float) {
+        Gdx.gl.glClearColor(0f, 0f, 0f, 1f)
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT)
+        update(delta)
+
+        joinLobbyStage.act(delta)
+        joinLobbyStage.draw()
+    }
+
+
+}

--- a/core/src/main/kotlin/no/ntnu/beardblaster/view/LoadingScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/view/LoadingScreen.kt
@@ -10,32 +10,33 @@ import ktx.log.logger
 import no.ntnu.beardblaster.AbstractScreen
 import no.ntnu.beardblaster.BeardBlasterGame
 import no.ntnu.beardblaster.assets.Assets
+import no.ntnu.beardblaster.user.UserAuth
 import kotlin.math.roundToInt
 
 private val LOG = logger<LoadingScreen>()
 
 class LoadingScreen(game: BeardBlasterGame) : AbstractScreen(game) {
-    //Load assets
     init {
+        // Load assets
         queueAsset()
     }
-    //private vars
+
     private var font: BitmapFont = BitmapFont(Gdx.files.internal("font_nevis/nevis.fnt"))
     private val shapeRenderer = ShapeRenderer()
     private var progress = 0f
 
     override fun show() {
-        LOG.debug { "LOADING screen" }
+        LOG.debug { "LOADING Screen" }
     }
 
     override fun update(delta: Float) {
         progress = Assets.assetManager.progress.roundToInt().toFloat()
-        //Check iff assetManager is done loading
+        // Check if assetManager is done loading
         if (Assets.assetManager.update()) {
-            if (Gdx.input.justTouched()) {
-                //Change screen
-                game.setScreen<LoginMenuScreen>()
-            }
+            // Go to correct menu screen when done loading
+            if (UserAuth().isLoggedIn()) {
+                game.setScreen<MenuScreen>()
+            } else game.setScreen<LoginMenuScreen>()
         }
     }
 
@@ -45,19 +46,19 @@ class LoadingScreen(game: BeardBlasterGame) : AbstractScreen(game) {
         //Draw the progress bar
         shapeRenderer.use(ShapeRenderer.ShapeType.Filled, cam.combined)
         {
-            it.rect(50f,(cam.viewportHeight / 2) -12f, cam.viewportWidth -50, 25f )
+            it.rect(50f, (cam.viewportHeight / 2) - 12f, cam.viewportWidth - 50, 25f)
             it.color = Color.RED
-            it.rect(50f, (cam.viewportHeight / 2) -12f , progress* (cam.viewportWidth -50), 25f )
+            it.rect(50f, (cam.viewportHeight / 2) - 12f, progress * (cam.viewportWidth - 50), 25f)
         }
 
         //Draw the progress text
         batch.use(cam.combined)
         {
-            font.draw(it, (100*progress).toString() + "% Loading Assets", 100f, 200f)
+            font.draw(it, (100 * progress).toString() + "% Loading Assets", 100f, 200f)
         }
     }
 
-    override fun resize(width:  Int, height: Int) {
+    override fun resize(width: Int, height: Int) {
         viewport.update(width, height, true)
     }
 

--- a/core/src/main/kotlin/no/ntnu/beardblaster/view/LobbyScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/view/LobbyScreen.kt
@@ -18,7 +18,7 @@ import no.ntnu.beardblaster.worldWidth
 
 private val LOG = logger<LoginScreen>()
 
-class JoinLobbyScreen(game: BeardBlasterGame) : AbstractScreen(game) {
+class LobbyScreen(game: BeardBlasterGame) : AbstractScreen(game) {
     private lateinit var skin: Skin
     private lateinit var table: Table
     private lateinit var heading: Label
@@ -26,19 +26,20 @@ class JoinLobbyScreen(game: BeardBlasterGame) : AbstractScreen(game) {
     private lateinit var leftTable: Table
     private lateinit var rightTable: Table
 
-    private lateinit var codeInput: TextField
-
-    private lateinit var submitCodeBtn: TextButton
+    private lateinit var codeLabel: Label
+    private lateinit var infoLabel: Label
+    
+    private lateinit var startGameBtn: TextButton
     private lateinit var backBtn: Button
 
-    private val joinLobbyStage: Stage by lazy {
+    private val lobbyStage: Stage by lazy {
         val result = Stage(FitViewport(worldWidth, worldHeight))
         Gdx.input.inputProcessor = result
         result
     }
 
     override fun show() {
-        LOG.debug { "JOIN LOBBY Screen" }
+        LOG.debug { "LOBBY SCREEN SHOWN" }
 
         skin = Skin(Assets.assetManager.get(Assets.atlas))
         table = Table(skin)
@@ -51,10 +52,19 @@ class JoinLobbyScreen(game: BeardBlasterGame) : AbstractScreen(game) {
         val standardFont = Assets.assetManager.get(Assets.standardFont)
 
         Label.LabelStyle(standardFont, Color.BLACK).also {
-            heading = Label("Join Game", it)
+            heading = Label("Lobby", it)
             heading.setFontScale(2f)
             it.background = skin.getDrawable("modal_fancy_header")
             heading.setAlignment(Align.center)
+        }
+        Label.LabelStyle(standardFont, Color.BLACK).also {
+            codeLabel = Label("39281", it)
+            codeLabel.setFontScale(1.5f)
+            codeLabel.setAlignment(Align.center)
+
+            infoLabel = Label("Share this code with a friend to start playing", it)
+            infoLabel.setFontScale(1f)
+            infoLabel.setAlignment(Align.center)
         }
 
         val buttonStyle = TextButton.TextButtonStyle()
@@ -70,20 +80,9 @@ class JoinLobbyScreen(game: BeardBlasterGame) : AbstractScreen(game) {
         skin.getDrawable("modal_fancy_header_button_red_cross_left").also { backBtnStyle.up = it }
 
 
-        submitCodeBtn = TextButton("SUBMIT", buttonStyle)
+        startGameBtn = TextButton("START GAME", buttonStyle)
+        // startGameBtn.isDisabled = true // TODO: Disabled start button until two players in lobby (or remove start button altogether and just start automatically
         backBtn = Button(backBtnStyle)
-        val textInputStyle = TextField.TextFieldStyle()
-
-        textInputStyle.also {
-            it.background = skin.getDrawable("input_texture_dark")
-            it.fontColor = Color.BROWN
-            it.font = standardFont
-            it.messageFontColor = Color.GRAY
-        }
-
-        codeInput = TextField("", textInputStyle)
-        codeInput.messageText = "Enter game code.."
-
 
         // Creating table
         rightTable.apply {
@@ -91,9 +90,11 @@ class JoinLobbyScreen(game: BeardBlasterGame) : AbstractScreen(game) {
             this.background = skin.getDrawable("modal_fancy")
             this.add(heading)
             this.row()
-            this.add(codeInput).width(570f)
+            this.add(codeLabel).pad((30f))
             this.row()
-            this.add(submitCodeBtn)
+            this.add(infoLabel)
+            this.row()
+            this.add(startGameBtn)
         }
 
         val stack = Stack()
@@ -109,17 +110,17 @@ class JoinLobbyScreen(game: BeardBlasterGame) : AbstractScreen(game) {
             this.add(rightTable).width(viewport.worldWidth * 0.9f).fillY()
         }
         // Adding actors to the stage
-        joinLobbyStage.addActor(table)
+        lobbyStage.addActor(table)
 
-        Gdx.input.inputProcessor = joinLobbyStage
+        Gdx.input.inputProcessor = lobbyStage
 
     }
 
     override fun update(delta: Float) {
-        submitCodeBtn.onClick {
-            // TODO: Set off handling if code is valid. If so, join lobby (go to lobby screen)
-            // but if not, show feedback to user that the code is not connected to an active game
-            game.setScreen<LobbyScreen>()
+        startGameBtn.onClick {
+            // When two players have joined the game, the host can chose to start it
+            // (or alternatively just start immediately (might be simpler))
+            game.setScreen<GameplayScreen>()
         }
         backBtn.onClick {
             game.setScreen<MenuScreen>()
@@ -131,7 +132,8 @@ class JoinLobbyScreen(game: BeardBlasterGame) : AbstractScreen(game) {
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT)
         update(delta)
 
-        joinLobbyStage.act(delta)
-        joinLobbyStage.draw()
+        lobbyStage.act(delta)
+        lobbyStage.draw()
+
     }
 }

--- a/core/src/main/kotlin/no/ntnu/beardblaster/view/LoginMenuScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/view/LoginMenuScreen.kt
@@ -22,33 +22,31 @@ import no.ntnu.beardblaster.worldWidth
 private val LOG = logger<LoginMenuScreen>()
 
 class LoginMenuScreen(game: BeardBlasterGame) : AbstractScreen(game) {
-
-
     private lateinit var skin: Skin
     private lateinit var table: Table
     private lateinit var heading: Label
 
-    private lateinit var buttonExit: TextButton
-    private lateinit var buttonLogin: TextButton
-    private lateinit var buttonRegister: TextButton
+    private lateinit var exitBtn: TextButton
+    private lateinit var loginBtn: TextButton
+    private lateinit var registerBtn: TextButton
 
     private val loginMenuStage: Stage by lazy {
         val result = Stage(FitViewport(worldWidth, worldHeight))
         Gdx.input.inputProcessor = result
         result
     }
+
     override fun show() {
-        LOG.debug { "LOGINMENU Screen" }
-        //Resetting inputprocessor to correct stage
-        Gdx.input.inputProcessor = loginMenuStage
+        LOG.debug { "LOGIN MENU Screen" }
+
         skin = Skin(Assets.assetManager.get(Assets.atlas))
         table = Table(skin)
-        table.setBounds(0f,0f, viewport.worldWidth, viewport.worldHeight)
+        table.setBounds(0f, 0f, viewport.worldWidth, viewport.worldHeight)
 
-        //fonts
-        var standardFont = Assets.assetManager.get(Assets.standardFont)
+        // Fonts
+        val standardFont = Assets.assetManager.get(Assets.standardFont)
 
-        //creating buttons
+        // Creating buttons
         val textButtonStyle = TextButton.TextButtonStyle()
         skin.getDrawable("button_default").also { textButtonStyle.up = it }
         skin.getDrawable("button_default_hover").also { textButtonStyle.over = it }
@@ -57,58 +55,57 @@ class LoginMenuScreen(game: BeardBlasterGame) : AbstractScreen(game) {
         textButtonStyle.pressedOffsetY = -4f
         textButtonStyle.font = standardFont
 
-        buttonExit = TextButton("EXIT", textButtonStyle)
-        buttonLogin = TextButton("LOGIN", textButtonStyle)
-        buttonRegister = TextButton("REGISTER", textButtonStyle)
+        exitBtn = TextButton("EXIT GAME", textButtonStyle)
+        loginBtn = TextButton("LOGIN", textButtonStyle)
+        registerBtn = TextButton("REGISTER", textButtonStyle)
 
-        //Creating heading
+        // Creating heading
         val headingStyle = Label.LabelStyle(standardFont, Color.BLACK).also {
-            heading = Label("BEARDBLASTER", it)
+            heading = Label("BeardBlaster", it)
             heading.setFontScale(2f)
             it.background = skin.getDrawable("modal_fancy_header")
             heading.setAlignment(Align.center)
         }
 
-        //Creating table
+        // Creating table
         table.apply {
             this.background = skin.getDrawable("modal_fancy")
             this.add(heading).pad(50f)
             this.row()
-            this.add(buttonLogin).pad(40f)
+            this.add(loginBtn).pad(40f)
             this.row()
-            this.add(buttonRegister).pad(40f)
+            this.add(registerBtn).pad(40f)
             this.row()
-            this.add(buttonExit).pad(40f)
+            this.add(exitBtn).pad(40f)
         }
 
         // Adding actors to the stage
         loginMenuStage.addActor(table)
 
+        Gdx.input.inputProcessor = loginMenuStage
 
     }
 
     override fun update(delta: Float) {
-        buttonLogin.onClick {
+        loginBtn.onClick {
             game.setScreen<LoginScreen>()
         }
-        buttonExit.onClick {
-            Gdx.app.exit()
-        }
-        buttonRegister.onClick {
+        registerBtn.onClick {
             game.setScreen<RegisterScreen>()
         }
-
+        exitBtn.onClick {
+            Gdx.app.exit()
+        }
     }
 
     override fun render(delta: Float) {
-        Gdx.gl.glClearColor(0f,0f,0f,1f)
+        Gdx.gl.glClearColor(0f, 0f, 0f, 1f)
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT)
         update(delta)
 
         loginMenuStage.act(delta)
         loginMenuStage.draw()
     }
-
 
 
 }

--- a/core/src/main/kotlin/no/ntnu/beardblaster/view/LoginScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/view/LoginScreen.kt
@@ -19,14 +19,6 @@ import no.ntnu.beardblaster.worldWidth
 private val LOG = logger<LoginScreen>()
 
 class LoginScreen(game: BeardBlasterGame) : AbstractScreen(game) {
-
-    private val loginStage: Stage by lazy {
-        val result = Stage(FitViewport(worldWidth, worldHeight))
-        Gdx.input.inputProcessor = result
-        result
-    }
-
-
     private lateinit var skin: Skin
     private lateinit var table: Table
     private lateinit var heading: Label
@@ -40,13 +32,19 @@ class LoginScreen(game: BeardBlasterGame) : AbstractScreen(game) {
     private lateinit var emailInput: TextField
     private lateinit var passwordInput: TextField
 
+    private val loginStage: Stage by lazy {
+        val result = Stage(FitViewport(worldWidth, worldHeight))
+        Gdx.input.inputProcessor = result
+        result
+    }
+
     override fun show() {
-        LOG.debug { "LOGIN SCREEN SHOWN" }
+        LOG.debug { "LOGIN SCREEN" }
 
         Gdx.input.inputProcessor = loginStage
         skin = Skin(Assets.assetManager.get(Assets.atlas))
         table = Table(skin)
-        table.setBounds(0f,0f, viewport.worldWidth, viewport.worldHeight)
+        table.setBounds(0f, 0f, viewport.worldWidth, viewport.worldHeight)
 
         rightTable = Table(skin)
         leftTable = Table(skin)
@@ -69,7 +67,7 @@ class LoginScreen(game: BeardBlasterGame) : AbstractScreen(game) {
             buttonStyle.font = this
         }
 
-        val backButtonStyle =  Button.ButtonStyle()
+        val backButtonStyle = Button.ButtonStyle()
         skin.getDrawable("modal_fancy_header_button_red_cross_left").also { backButtonStyle.down = it }
         skin.getDrawable("modal_fancy_header_button_red_cross_left").also { backButtonStyle.up = it }
 
@@ -93,8 +91,8 @@ class LoginScreen(game: BeardBlasterGame) : AbstractScreen(game) {
         passwordInput.messageText = "Enter password.."
 
 
-        //%TODO(find out why input fields renders with wrong width)
-        //Creating table
+        // TODO: find out why input fields renders with wrong width
+        // Creating table
         rightTable.apply {
             this.defaults().pad(30f)
             this.background = skin.getDrawable("modal_fancy")
@@ -119,6 +117,7 @@ class LoginScreen(game: BeardBlasterGame) : AbstractScreen(game) {
             this.add(leftTable).width(91f).expandY().fillY()
             this.add(rightTable).width(viewport.worldWidth * 0.9f).fillY()
         }
+
         // Adding actors to the stage
         loginStage.addActor(table)
 
@@ -134,20 +133,11 @@ class LoginScreen(game: BeardBlasterGame) : AbstractScreen(game) {
     }
 
     override fun render(delta: Float) {
-        Gdx.gl.glClearColor(0f,0f,0f,1f)
+        Gdx.gl.glClearColor(0f, 0f, 0f, 1f)
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT)
         update(delta)
 
         loginStage.act(delta)
         loginStage.draw()
-
-    }
-
-    override fun resize(width: Int, height: Int) {
-        super.resize(width, height)
-    }
-
-    override fun dispose() {
-        super.dispose()
     }
 }

--- a/core/src/main/kotlin/no/ntnu/beardblaster/view/LoginScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/view/LoginScreen.kt
@@ -13,6 +13,7 @@ import ktx.log.logger
 import no.ntnu.beardblaster.AbstractScreen
 import no.ntnu.beardblaster.BeardBlasterGame
 import no.ntnu.beardblaster.assets.Assets
+import no.ntnu.beardblaster.user.UserAuth
 import no.ntnu.beardblaster.worldHeight
 import no.ntnu.beardblaster.worldWidth
 
@@ -125,6 +126,9 @@ class LoginScreen(game: BeardBlasterGame) : AbstractScreen(game) {
 
     override fun update(delta: Float) {
         loginButton.onClick {
+            if (!UserAuth().isLoggedIn() && emailInput.text.isNotEmpty() && passwordInput.text.isNotEmpty()) {
+                UserAuth().signIn(emailInput.text, passwordInput.text)
+            }
             game.setScreen<MenuScreen>()
         }
         backButton.onClick {

--- a/core/src/main/kotlin/no/ntnu/beardblaster/view/MenuScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/view/MenuScreen.kt
@@ -13,6 +13,7 @@ import ktx.log.logger
 import no.ntnu.beardblaster.AbstractScreen
 import no.ntnu.beardblaster.BeardBlasterGame
 import no.ntnu.beardblaster.assets.Assets
+import no.ntnu.beardblaster.user.UserAuth
 import no.ntnu.beardblaster.worldHeight
 import no.ntnu.beardblaster.worldWidth
 
@@ -21,6 +22,16 @@ private val LOG = logger<MenuScreen>()
 
 
 class MenuScreen(game: BeardBlasterGame) : AbstractScreen(game) {
+    private lateinit var skin: Skin
+    private lateinit var table: Table
+    private lateinit var heading: Label
+
+    private lateinit var createGameBtn: TextButton
+    private lateinit var joinGameBtn: TextButton
+    private lateinit var highscoreBtn: TextButton
+    private lateinit var tutorialBtn: TextButton
+    private lateinit var logoutBtn: TextButton
+    private lateinit var exitBtn: TextButton
 
     private val menuStage: Stage by lazy {
         val result = Stage(FitViewport(worldWidth, worldHeight))
@@ -28,47 +39,36 @@ class MenuScreen(game: BeardBlasterGame) : AbstractScreen(game) {
         result
     }
 
-
-    private lateinit var skin: Skin
-    private lateinit var table: Table
-    private lateinit var heading: Label
-
-    private lateinit var createGameButton: TextButton
-    private lateinit var joinGameButton: TextButton
-    private lateinit var highscoreButton: TextButton
-    private lateinit var tutorialButton: TextButton
-
-
-
     override fun show() {
         LOG.debug { "MENU Screen" }
 
-        Gdx.input.inputProcessor = menuStage
         skin = Skin(Assets.assetManager.get(Assets.atlas))
         table = Table(skin)
-        table.setBounds(0f,0f, viewport.worldWidth, viewport.worldHeight)
+        table.setBounds(0f, 0f, viewport.worldWidth, viewport.worldHeight)
 
         val standardFont = Assets.assetManager.get(Assets.standardFont)
 
         Label.LabelStyle(standardFont, Color.BLACK).also {
-            heading = Label("Welcome <Username>", it)
+            heading = Label("Welcome Wizard", it)
             heading.setFontScale(2f)
             it.background = skin.getDrawable("modal_fancy_header")
             heading.setAlignment(Align.center)
         }
 
-        val createUserButtonStyle = TextButton.TextButtonStyle()
-        skin.getDrawable("button_default_pressed").also { createUserButtonStyle.down = it }
-        skin.getDrawable("button_default").also { createUserButtonStyle.up = it }
+        val buttonStyle = TextButton.TextButtonStyle()
+        skin.getDrawable("button_default_pressed").also { buttonStyle.down = it }
+        skin.getDrawable("button_default").also { buttonStyle.up = it }
 
         standardFont.apply {
-            createUserButtonStyle.font = this
+            buttonStyle.font = this
         }
 
-        createGameButton = TextButton("Create Game", createUserButtonStyle)
-        joinGameButton = TextButton("Join Game", createUserButtonStyle)
-        highscoreButton = TextButton("LeaderBeard", createUserButtonStyle)
-        tutorialButton = TextButton("Tutorial", createUserButtonStyle)
+        createGameBtn = TextButton("CREATE GAME", buttonStyle)
+        joinGameBtn = TextButton("JOIN GAME", buttonStyle)
+        highscoreBtn = TextButton("LEADERBEARD", buttonStyle)
+        tutorialBtn = TextButton("TUTORIAL", buttonStyle)
+        logoutBtn = TextButton("LOGOUT", buttonStyle)
+        exitBtn = TextButton("EXIT GAME", buttonStyle)
 
         val textInputStyle = TextField.TextFieldStyle()
 
@@ -79,46 +79,59 @@ class MenuScreen(game: BeardBlasterGame) : AbstractScreen(game) {
             it.messageFontColor = Color.GRAY
         }
 
-
-
-        //%TODO(find out why input fields renders with wrong width)
-        //Creating table
         table.apply {
-            this.defaults().pad(30f)
+            this.defaults().pad(20f)
             this.background = skin.getDrawable("background")
-            this.add(heading)
+            this.add(heading).colspan(4).center()
             this.row()
-            this.add(createGameButton)
+            this.add(createGameBtn).colspan(4).center()
             this.row()
-            this.add(joinGameButton)
+            this.add(joinGameBtn).colspan(4).center()
             this.row()
-            this.add(highscoreButton)
+            this.add(highscoreBtn).colspan(2).center()
+            this.add(tutorialBtn).colspan(2).center()
             this.row()
-            this.add(tutorialButton)
+            this.add(logoutBtn).colspan(2).center()
+            this.add(exitBtn).colspan(2).center()
         }
 
         // Adding actors to the stage
         menuStage.addActor(table)
 
-
+        Gdx.input.inputProcessor = menuStage
     }
 
     override fun update(delta: Float) {
-
-        tutorialButton.onClick {
+        createGameBtn.onClick {
+            // Handle creation of game, and then go to Lobby screen to display code and wait for player 2
+            game.setScreen<LobbyScreen>()
+        }
+        joinGameBtn.onClick {
+            game.setScreen<JoinLobbyScreen>()
+        }
+        highscoreBtn.onClick {
+            game.setScreen<HighscoreScreen>()
+        }
+        tutorialBtn.onClick {
+            game.setScreen<TutorialScreen>()
+        }
+        logoutBtn.onClick {
+            if (UserAuth().isLoggedIn()) {
+                UserAuth().signOut()
+            }
             game.setScreen<LoginMenuScreen>()
+        }
+        exitBtn.onClick {
+            Gdx.app.exit()
         }
     }
 
     override fun render(delta: Float) {
-        Gdx.gl.glClearColor(0f,0f,0f,1f)
+        Gdx.gl.glClearColor(0f, 0f, 0f, 1f)
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT)
         update(delta)
 
         menuStage.act(delta)
         menuStage.draw()
-
     }
-
-
 }

--- a/core/src/main/kotlin/no/ntnu/beardblaster/view/RegisterScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/view/RegisterScreen.kt
@@ -17,7 +17,24 @@ import no.ntnu.beardblaster.worldHeight
 import no.ntnu.beardblaster.worldWidth
 
 private val LOG = logger<RegisterScreen>()
+
 class RegisterScreen(game: BeardBlasterGame) : AbstractScreen(game) {
+    private var hasRegistered = false
+
+    private lateinit var skin: Skin
+
+    private lateinit var table: Table
+    private lateinit var leftTable: Table
+    private lateinit var rightTable: Table
+    private lateinit var heading: Label
+
+    private lateinit var backBtn: Button
+    private lateinit var createBtn: TextButton
+
+    private lateinit var userNameInput: TextField
+    private lateinit var emailInput: TextField
+    private lateinit var passwordInput: TextField
+    private lateinit var rePasswordInput: TextField
 
     private val registrationStage: Stage by lazy {
         val result = Stage(FitViewport(worldWidth, worldHeight))
@@ -25,29 +42,12 @@ class RegisterScreen(game: BeardBlasterGame) : AbstractScreen(game) {
         result
     }
 
-
-    private lateinit var skin: Skin
-
-    private lateinit var table: Table
-    private lateinit var leftTable: Table
-    private lateinit var rightTable: Table
-
-    private lateinit var heading: Label
-
-    private lateinit var createButton: TextButton
-    private lateinit var backButton: Button
-
-    private lateinit var userNameInput: TextField
-    private lateinit var emailInput: TextField
-    private lateinit var passwordInput: TextField
-    private lateinit var rePasswordInput: TextField
-    private var hasRegistered = false
     override fun show() {
-        LOG.debug { "Registration Screen Shown" }
+        LOG.debug { "REGISTRATION Screen" }
         Gdx.input.inputProcessor = registrationStage
         skin = Skin(Assets.assetManager.get(Assets.atlas))
         table = Table(skin)
-        table.setBounds(0f,0f, viewport.worldWidth, viewport.worldHeight)
+        table.setBounds(0f, 0f, viewport.worldWidth, viewport.worldHeight)
         rightTable = Table(skin)
         leftTable = Table(skin)
 
@@ -64,17 +64,17 @@ class RegisterScreen(game: BeardBlasterGame) : AbstractScreen(game) {
         skin.getDrawable("button_default_pressed").also { createUserButtonStyle.down = it }
         skin.getDrawable("button_default").also { createUserButtonStyle.up = it }
 
-        val backButtonStyle =  Button.ButtonStyle()
+        val backBtnStyle = Button.ButtonStyle()
         skin.getDrawable("modal_fancy_header_button_red_cross_left").also {
-            backButtonStyle.down = it
-            backButtonStyle.up = it
+            backBtnStyle.down = it
+            backBtnStyle.up = it
         }
 
         standardFont.apply {
             createUserButtonStyle.font = this
         }
-        backButton = Button(backButtonStyle)
-        createButton = TextButton("CREATE WIZARD", createUserButtonStyle)
+        backBtn = Button(backBtnStyle)
+        createBtn = TextButton("CREATE WIZARD", createUserButtonStyle)
 
         val textInputStyle = TextField.TextFieldStyle()
 
@@ -98,10 +98,6 @@ class RegisterScreen(game: BeardBlasterGame) : AbstractScreen(game) {
         rePasswordInput.messageText = "Re-enter password.."
         rePasswordInput.isPasswordMode = true
 
-
-        //%TODO(find out why input fields renders with wrong width)
-        //Creating table
-
         rightTable.apply {
             this.defaults().pad(30f)
             this.background = skin.getDrawable("modal_fancy")
@@ -115,18 +111,16 @@ class RegisterScreen(game: BeardBlasterGame) : AbstractScreen(game) {
             this.row()
             this.add(rePasswordInput).width(570f)
             this.row()
-            this.add(createButton).width(370f)
+            this.add(createBtn).width(370f)
         }
 
         val stack = Stack()
-        stack.add(backButton)
+        stack.add(backBtn)
 
         leftTable.apply {
             this.top()
             this.add(stack).fillY().align(Align.top).padTop(50f)
         }
-
-
 
         table.apply {
             this.background = skin.getDrawable("background")
@@ -134,34 +128,29 @@ class RegisterScreen(game: BeardBlasterGame) : AbstractScreen(game) {
             this.add(rightTable).width(viewport.worldWidth * 0.9f).fillY()
         }
 
-        // Adding actors to the stage
         registrationStage.addActor(table)
     }
 
     override fun update(delta: Float) {
-        createButton.onClick {
+        createBtn.onClick {
             /*if(!hasRegistered) {
                 UserAuth().createUser(emailInput.text, passwordInput.text, userNameInput.text)
                 hasRegistered = true
             }*/
             game.setScreen<LoginMenuScreen>()
         }
-        backButton.onClick {
+        backBtn.onClick {
             game.setScreen<LoginMenuScreen>()
         }
     }
 
     override fun render(delta: Float) {
-        Gdx.gl.glClearColor(0f,0f,0f,1f)
+        Gdx.gl.glClearColor(0f, 0f, 0f, 1f)
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT)
         update(delta)
 
         registrationStage.act(delta)
         registrationStage.draw()
-
-    }
-
-    override fun resize(width: Int, height: Int) {
 
     }
 }

--- a/core/src/main/kotlin/no/ntnu/beardblaster/view/TutorialScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/view/TutorialScreen.kt
@@ -20,71 +20,64 @@ import no.ntnu.beardblaster.worldHeight
 import no.ntnu.beardblaster.worldWidth
 
 
-private val LOG = logger<CreateLobbyScreen>()
+private val LOG = logger<TutorialScreen>()
 
 
-class CreateLobbyScreen(game: BeardBlasterGame) : AbstractScreen(game) {
+class TutorialScreen(game: BeardBlasterGame) : AbstractScreen(game) {
     private lateinit var skin: Skin
     private lateinit var table: Table
     private lateinit var heading: Label
 
-    private lateinit var btnStartGame: TextButton
-    private lateinit var btnBack: TextButton
+    private lateinit var closeTutorialBtn: TextButton
 
-    private val createLobbyStage: Stage by lazy {
+    private val tutorialStage: Stage by lazy {
         val result = Stage(FitViewport(worldWidth, worldHeight))
         Gdx.input.inputProcessor = result
         result
     }
 
     override fun show() {
-        LOG.debug { "CREATE LOBBY Screen" }
+        LOG.debug { "TUTORIAL Screen" }
 
         skin = Skin(Assets.assetManager.get(Assets.atlas))
         table = Table(skin)
         table.setBounds(0f, 0f, viewport.worldWidth, viewport.worldHeight)
 
-        // Fonts
         val standardFont = Assets.assetManager.get(Assets.standardFont)
 
-        // Creating buttons
-        val textButtonStyle = TextButton.TextButtonStyle()
-        skin.getDrawable("button_default").also { textButtonStyle.up = it }
-        skin.getDrawable("button_default_hover").also { textButtonStyle.over = it }
-        skin.getDrawable("button_default_pressed").also { textButtonStyle.down = it }
-        textButtonStyle.pressedOffsetX = 4f
-        textButtonStyle.pressedOffsetY = -4f
-        textButtonStyle.font = standardFont
-
-        btnStartGame = TextButton("START GAME", textButtonStyle)
-        btnBack = TextButton("GO BACK", textButtonStyle)
-
-        // Creating heading
         Label.LabelStyle(standardFont, Color.BLACK).also {
-            heading = Label("CREATE LOBBY", it)
+            heading = Label("Tutorial", it)
             heading.setFontScale(2f)
             it.background = skin.getDrawable("modal_fancy_header")
             heading.setAlignment(Align.center)
         }
 
+        val buttonStyle = TextButton.TextButtonStyle()
+        skin.getDrawable("button_default_pressed").also { buttonStyle.down = it }
+        skin.getDrawable("button_default").also { buttonStyle.up = it }
+        standardFont.apply {
+            buttonStyle.font = this
+        }
+
+        closeTutorialBtn = TextButton("CLOSE", buttonStyle)
+
         // Creating table
-        table.background = skin.getDrawable("modal_fancy")
-        table.add(heading).pad(50f)
-        table.row()
-        table.add(btnStartGame).pad(40f)
-        table.row()
-        table.add(btnBack).pad(40f)
-        table.row()
+        table.apply {
+            this.defaults().pad(30f)
+            this.background = skin.getDrawable("background")
+            this.add(heading)
+            this.row()
+            this.add(closeTutorialBtn)
+        }
 
         // Adding actors to the stage
-        createLobbyStage.addActor(table)
+        tutorialStage.addActor(table)
+
+        Gdx.input.inputProcessor = tutorialStage
     }
 
     override fun update(delta: Float) {
-        btnStartGame.onClick {
-            game.setScreen<GameplayScreen>()
-        }
-        btnBack.onClick {
+        closeTutorialBtn.onClick {
             game.setScreen<MenuScreen>()
         }
     }
@@ -94,9 +87,7 @@ class CreateLobbyScreen(game: BeardBlasterGame) : AbstractScreen(game) {
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT)
         update(delta)
 
-        createLobbyStage.act(delta)
-        createLobbyStage.draw()
+        tutorialStage.act(delta)
+        tutorialStage.draw()
     }
-
-
 }


### PR DESCRIPTION
- Simplify logging in UserAuth and add method to check if user is logged in
- Make loading screen automatically load the correct menu screen when done
- Add Lobby screen, Join lobby screen, Highscore screen, Tutorial screen, Gameplay screen (improved visuals)
- Complete navigation structure between screens
- Clean up code for consistency
- Connect login form to firebase auth

![Screenshot_20210319_201029](https://user-images.githubusercontent.com/25204035/111831170-54dbe780-8932-11eb-8fcf-dd321be2ec2f.png)

![Screenshot_20210319_201042](https://user-images.githubusercontent.com/25204035/111831201-5e654f80-8932-11eb-8fb5-2eccf21b695f.png)

Problems: 
- When pressing a button, the event renders many times, e.g. when clicking log out button (TextButton with onClick event), the function is called like over 10 times. When creating a button that signs you in, Fireauth malfunctions because the event is sent so many times. Created a separate issue for fixing this #29 
- We are duplicating a lot of styles. Created a separate issue for looking into refactoring this #28 