### PR TITLE
Make sure AssetManager is initialized on startup

### DIFF
--- a/core/src/main/kotlin/no/ntnu/beardblaster/BeardBlasterGame.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/BeardBlasterGame.kt
@@ -2,6 +2,7 @@ package no.ntnu.beardblaster
 
 import com.badlogic.gdx.Application
 import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.assets.AssetManager
 import com.badlogic.gdx.graphics.OrthographicCamera
 import com.badlogic.gdx.graphics.g2d.Batch
 import com.badlogic.gdx.graphics.g2d.SpriteBatch
@@ -26,7 +27,7 @@ class BeardBlasterGame : KtxGame<AbstractScreen>() {
         // Set debug level
         Gdx.app.logLevel = Application.LOG_DEBUG
         LOG.debug { "Create game instance" }
-        
+        Assets.assetManager = AssetManager()
         initScreens()
     }
 

--- a/core/src/main/kotlin/no/ntnu/beardblaster/assets/Assets.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/assets/Assets.kt
@@ -10,7 +10,7 @@ import com.badlogic.gdx.graphics.g2d.TextureAtlas
 object Assets {
 
     // Define all assets that must be loaded during loading screen
-    var assetManager = AssetManager()
+    lateinit var assetManager: AssetManager
     val loadBar = AssetDescriptor<Texture>("graphics/load_bar.png", Texture::class.java)
     val loginImg = AssetDescriptor<Texture>("graphics/login.png", Texture::class.java)
     val test1 = AssetDescriptor<Texture>("bar_container.png", Texture::class.java)


### PR DESCRIPTION
According to [1], declaring an AssetManager static will cause problems
on Android. Initializing the AssetManager as a member of a Kotlin
Singleton object is essentially the same. To ensure the assetManager
member is initialized and available when the application starts, it is
now declared with lateinit and initialized in the create() function of
the BeardBlasterGame class.

[1]: https://github.com/libgdx/libgdx/wiki/Managing-your-assets#creating-an-assetmanager

Closes #31