### PR TITLE
Add MVP pattern to remaining (viable) screens

### DIFF
--- a/core/src/main/kotlin/no/ntnu/beardblaster/BaseScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/BaseScreen.kt
@@ -20,7 +20,7 @@ abstract class BaseScreen(
         result
     }
 
-    // Template method pattern: https://refactoring.guru/design-patterns/template-method
+    // Template method pattern
     final override fun show() {
         stage.clear()
         initComponents()
@@ -32,7 +32,7 @@ abstract class BaseScreen(
     abstract fun initScreen() // Abstract step
     open fun initComponents() {}
     abstract fun setBtnEventListeners()
-    abstract fun update(delta: Float)
+    open fun update(delta: Float) {}
 
     override fun render(delta: Float) {
         Gdx.gl.glClearColor(0f, 0f, 0f, 1f)

--- a/core/src/main/kotlin/no/ntnu/beardblaster/LoadingScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/LoadingScreen.kt
@@ -12,7 +12,7 @@ import ktx.async.KtxAsync
 import ktx.graphics.use
 import no.ntnu.beardblaster.assets.*
 import no.ntnu.beardblaster.commons.user.User
-import no.ntnu.beardblaster.game.GameplayScreen
+import no.ntnu.beardblaster.game.GamePlayScreen
 import no.ntnu.beardblaster.leaderboard.LeaderBoardScreen
 import no.ntnu.beardblaster.lobby.JoinLobbyScreen
 import no.ntnu.beardblaster.lobby.LobbyScreen
@@ -80,7 +80,7 @@ class LoadingScreen(
         game.addScreen(LeaderBoardScreen(game, batch, assets, camera))
         game.addScreen(LobbyScreen(game, batch, assets, camera))
         game.addScreen(JoinLobbyScreen(game, batch, assets, camera))
-        game.addScreen(GameplayScreen(game, batch, assets, camera))
+        game.addScreen(GamePlayScreen(game, batch, assets, camera))
     }
 
     override fun dispose() {

--- a/core/src/main/kotlin/no/ntnu/beardblaster/game/GamePlayScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/game/GamePlayScreen.kt
@@ -39,7 +39,7 @@ import no.ntnu.beardblaster.wizard.WizardTextures
 import java.util.*
 import kotlin.concurrent.schedule
 
-private val LOG = logger<GameplayScreen>()
+private val LOG = logger<GamePlayScreen>()
 
 enum class Phase {
     Preparation,
@@ -48,7 +48,7 @@ enum class Phase {
     GameOver
 }
 
-class GameplayScreen(
+class GamePlayScreen(
     game: BeardBlasterGame,
     batch: SpriteBatch,
     assets: AssetStorage,

--- a/core/src/main/kotlin/no/ntnu/beardblaster/leaderboard/LeaderBoardPresenter.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/leaderboard/LeaderBoardPresenter.kt
@@ -1,0 +1,45 @@
+package no.ntnu.beardblaster.leaderboard
+
+import kotlinx.coroutines.launch
+import ktx.async.KtxAsync
+import ktx.log.debug
+import ktx.log.logger
+import no.ntnu.beardblaster.BeardBlasterGame
+import no.ntnu.beardblaster.commons.leaderboard.BeardScore
+import no.ntnu.beardblaster.menu.MenuScreen
+import java.util.*
+
+private val LOG = logger<LeaderBoardPresenter>()
+
+class LeaderBoardPresenter(private val view: View, val game: BeardBlasterGame) : Observer {
+    private val leaderBoardHandler = LeaderBoardHandler()
+
+    interface View {
+        fun fillLeaderBoard(beardScores: List<BeardScore>)
+    }
+
+    fun init() {
+        leaderBoardHandler.addObserver(this)
+        KtxAsync.launch {
+            LOG.debug { "Summoning the beards…" }
+            leaderBoardHandler.getTopTenBeards()
+        }
+    }
+
+    fun onBackBtnClick() {
+        game.setScreen<MenuScreen>()
+        dispose()
+    }
+
+
+    override fun update(o: Observable, arg: Any?) {
+        if (o is LeaderBoardHandler) {
+            view.fillLeaderBoard(o.topTen)
+        }
+    }
+
+    fun dispose() {
+        leaderBoardHandler.deleteObserver(this)
+    }
+}
+

--- a/core/src/main/kotlin/no/ntnu/beardblaster/leaderboard/LeaderBoardScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/leaderboard/LeaderBoardScreen.kt
@@ -5,12 +5,8 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch
 import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
 import com.badlogic.gdx.utils.Align
-import kotlinx.coroutines.launch
 import ktx.actors.onClick
 import ktx.assets.async.AssetStorage
-import ktx.async.KtxAsync
-import ktx.log.debug
-import ktx.log.logger
 import ktx.scene2d.scene2d
 import ktx.scene2d.scrollPane
 import ktx.scene2d.table
@@ -21,21 +17,18 @@ import no.ntnu.beardblaster.WORLD_HEIGHT
 import no.ntnu.beardblaster.WORLD_WIDTH
 import no.ntnu.beardblaster.assets.Nls
 import no.ntnu.beardblaster.commons.leaderboard.BeardScore
-import no.ntnu.beardblaster.menu.MenuScreen
 import no.ntnu.beardblaster.ui.Image
 import no.ntnu.beardblaster.ui.get
 import no.ntnu.beardblaster.ui.headingLabel
-import java.util.*
-
-private val LOG = logger<LeaderBoardScreen>()
 
 class LeaderBoardScreen(
     game: BeardBlasterGame,
     batch: SpriteBatch,
     assets: AssetStorage,
     camera: OrthographicCamera,
-) : BaseScreen(game, batch, assets, camera), Observer {
-    private val leaderBoardHandler = LeaderBoardHandler()
+) : BaseScreen(game, batch, assets, camera), LeaderBoardPresenter.View {
+    private val presenter = LeaderBoardPresenter(this, game)
+
     private lateinit var table: Table
     private lateinit var backBtn: TextButton
     private val leaderBoard = LeaderBoard()
@@ -70,29 +63,21 @@ class LeaderBoardScreen(
     }
 
     override fun initScreen() {
-        leaderBoardHandler.addObserver(this)
-        KtxAsync.launch {
-            LOG.debug { "Summoning the beards…" }
-            leaderBoardHandler.getTopTenBeards()
-        }
+        presenter.init()
         stage.addActor(table)
         stage.addActor(backBtn)
     }
 
     override fun setBtnEventListeners() {
         backBtn.onClick {
-            game.setScreen<MenuScreen>()
+            presenter.onBackBtnClick()
         }
     }
 
-    override fun update(delta: Float) {}
-
-    override fun update(o: Observable, arg: Any?) {
-        if (o is LeaderBoardHandler) {
-            leaderBoard.clear()
-            for (score: BeardScore in o.topTen) {
-                leaderBoard.addScore(score)
-            }
+    override fun fillLeaderBoard(beardScores: List<BeardScore>) {
+        leaderBoard.clear()
+        for (score: BeardScore in beardScores) {
+            leaderBoard.addScore(score)
         }
     }
 }

--- a/core/src/main/kotlin/no/ntnu/beardblaster/lobby/JoinLobbyPresenter.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/lobby/JoinLobbyPresenter.kt
@@ -1,0 +1,100 @@
+package no.ntnu.beardblaster.lobby
+
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import ktx.async.KtxAsync
+import no.ntnu.beardblaster.BeardBlasterGame
+import no.ntnu.beardblaster.commons.State
+import no.ntnu.beardblaster.commons.game.Game
+import no.ntnu.beardblaster.game.GameData
+import no.ntnu.beardblaster.game.GamePlayScreen
+import no.ntnu.beardblaster.menu.MenuScreen
+import no.ntnu.beardblaster.user.UserData
+import pl.mk5.gdx.fireapp.GdxFIRAuth
+import java.util.*
+
+class JoinLobbyPresenter(private val view: View, val game: BeardBlasterGame) : Observer {
+    private var lobbyHandler: LobbyHandler = LobbyHandler()
+
+    interface View {
+        fun setErrorLabel(msg: String)
+        fun setErrorLabelVisibility(isVisible: Boolean)
+        fun isErrorLabelVisible(): Boolean
+        fun setWaitingLabel(msg: String)
+        fun setWaitingLabelFontScale(scale: Float)
+        fun setWaitingLabelVisibility(isVisible: Boolean)
+        fun setSubmitCodeBtnVisibility(isVisible: Boolean)
+    }
+
+    fun init() {
+        // Listen for updates on LobbyData
+        lobbyHandler.addObserver(this)
+    }
+
+    fun onSubmitCodeBtnClick(codeInput: String) {
+        if (codeInput.isNotEmpty() && codeInput.isNotBlank())
+
+            if (UserData.instance.user == null || GdxFIRAuth.inst().currentUser == null) {
+                view.setErrorLabel("Failed to join: Try to log into BeardBlaster again.")
+                view.setErrorLabelVisibility(true)
+                return
+            }
+        // This will eventually trigger "update()"
+        lobbyHandler.joinLobbyWithCode(codeInput)
+        view.setWaitingLabel("Verifying code...")
+        view.setWaitingLabelVisibility(true)
+    }
+
+    fun onBackBtnClick() {
+        KtxAsync.launch {
+            if (lobbyHandler.game != null) {
+                lobbyHandler.leaveLobby()?.collect {
+                    when (it) {
+                        is State.Success -> {
+                            game.setScreen<MenuScreen>()
+                        }
+                        is State.Failed -> {
+                            view.setErrorLabel("Failed to leave lobby.. Please retry.")
+                            view.setErrorLabelVisibility(true)
+                            if (view.isErrorLabelVisible()) {
+                                // Just force quit if it fails once more.
+                                game.setScreen<MenuScreen>()
+                            }
+                        }
+                    }
+                }
+            } else {
+                game.setScreen<MenuScreen>()
+            }
+        }
+    }
+
+    // Listens for changes on lobby -> when entering lobby and when lobby starts.
+    override fun update(o: Observable?, arg: Any?) {
+        if (o is LobbyHandler) {
+            if (arg is String) {
+                view.setErrorLabel(arg)
+                view.setErrorLabelVisibility(true)
+                view.setWaitingLabelVisibility(false)
+            }
+            if (arg is Game) {
+                if (arg.startedAt > 0L) {
+                    GameData.instance.game = arg
+                    dispose()
+                    game.setScreen<GamePlayScreen>()
+                } else {
+                    view.setErrorLabelVisibility(false)
+                    view.setWaitingLabelVisibility(true)
+                    view.setWaitingLabelFontScale(0.8f)
+                    view.setWaitingLabel("Success! Waiting for player to start the game.")
+                    view.setSubmitCodeBtnVisibility(false)
+                }
+            }
+        }
+    }
+
+    fun dispose() {
+        lobbyHandler.deleteObserver(this)
+    }
+}
+

--- a/core/src/main/kotlin/no/ntnu/beardblaster/lobby/JoinLobbyScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/lobby/JoinLobbyScreen.kt
@@ -23,7 +23,7 @@ import no.ntnu.beardblaster.assets.Nls
 import no.ntnu.beardblaster.commons.State
 import no.ntnu.beardblaster.commons.game.Game
 import no.ntnu.beardblaster.game.GameData
-import no.ntnu.beardblaster.game.GameplayScreen
+import no.ntnu.beardblaster.game.GamePlayScreen
 import no.ntnu.beardblaster.menu.MenuScreen
 import no.ntnu.beardblaster.ui.*
 import no.ntnu.beardblaster.user.UserData
@@ -117,8 +117,6 @@ class JoinLobbyScreen(
         }
     }
 
-    override fun update(delta: Float) {}
-
     // Listens for changes on lobby -> when entering lobby and when lobby starts.
     override fun update(o: Observable?, arg: Any?) {
         if (o is LobbyHandler) {
@@ -131,7 +129,7 @@ class JoinLobbyScreen(
                 if (arg.startedAt > 0L) {
                     GameData.instance.game = arg
                     lobbyHandler.deleteObserver(this)
-                    game.setScreen<GameplayScreen>()
+                    game.setScreen<GamePlayScreen>()
                 } else {
                     errorLabel.isVisible = false
                     waitingLabel.isVisible = true

--- a/core/src/main/kotlin/no/ntnu/beardblaster/lobby/LobbyPresenter.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/lobby/LobbyPresenter.kt
@@ -1,0 +1,141 @@
+package no.ntnu.beardblaster.lobby
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import ktx.async.KtxAsync
+import ktx.log.debug
+import ktx.log.error
+import ktx.log.logger
+import no.ntnu.beardblaster.BeardBlasterGame
+import no.ntnu.beardblaster.assets.Nls
+import no.ntnu.beardblaster.commons.State
+import no.ntnu.beardblaster.commons.game.Game
+import no.ntnu.beardblaster.game.GameData
+import no.ntnu.beardblaster.game.GamePlayScreen
+import no.ntnu.beardblaster.menu.MenuScreen
+import java.util.*
+
+private val LOG = logger<LobbyPresenter>()
+
+class LobbyPresenter(private val view: View, val game: BeardBlasterGame) : Observer {
+    private lateinit var subscription: Job
+    private var lobbyHandler: LobbyHandler = LobbyHandler()
+
+    interface View {
+        fun setInfoLabel(string: String)
+        fun setCodeLabel(code: String)
+        fun setOpponentLabel(string: String)
+        fun setOpponentBeardLengthLabel(beardLength: Float)
+        fun setStartGameBtnVisibility(isVisible: Boolean)
+    }
+
+    fun init() {
+        lobbyHandler.addObserver(this)
+        KtxAsync.launch {
+            lobbyHandler.createLobby()
+        }
+    }
+
+    fun onStartGameBtnClick() {
+        KtxAsync.launch {
+            lobbyHandler.startGame()?.collect {
+                when (it) {
+                    is State.Loading -> {
+                        view.setOpponentLabel("Starting game..")
+                    }
+                    is State.Failed -> {
+                        view.setOpponentLabel(it.message)
+                        LOG.error { it.message }
+                    }
+                    is State.Success -> {
+                        game.setScreen<GamePlayScreen>()
+                    }
+                }
+            }
+        }
+    }
+
+    fun onBackBtnClick() {
+        KtxAsync.launch {
+            if (lobbyHandler.game == null) {
+                game.setScreen<MenuScreen>()
+            } else {
+                lobbyHandler.cancelLobby()?.collect {
+                    when (it) {
+                        is State.Success -> {
+                            lobbyHandler.setGame(null)
+                            GameData.instance.game = null
+                            dispose()
+                            game.setScreen<MenuScreen>()
+                        }
+                        is State.Loading -> {
+
+                        }
+                        is State.Failed -> {
+                            LOG.error { it.message }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ExperimentalCoroutinesApi
+    override fun update(o: Observable?, arg: Any?) {
+        if (arg is Game) {
+            view.setCodeLabel(arg.code)
+
+            LOG.debug { "Game created - Subscribing to new game." }
+            LOG.debug { "Should I subscribe? ${!::subscription.isInitialized || !subscription.isActive}." }
+            LOG.debug { "Is initialized? ${::subscription.isInitialized}." }
+            LOG.debug { "Is active? ${::subscription.isInitialized && subscription.isActive}." }
+
+            if (::subscription.isInitialized && subscription.isActive) {
+                subscription.cancel()
+            }
+
+            if (!::subscription.isInitialized || !subscription.isActive) {
+                subscription = KtxAsync.launch {
+                    LOG.debug { "Running subscribe to game with id ${arg.id}" }
+
+                    LobbyRepository().subscribeToLobbyUpdates(arg.id).collect {
+                        when (it) {
+                            is State.Success -> {
+                                // On received update: Check if opponent of updated Game is not null
+                                if (it.data.opponent != null) {
+                                    // Player may now start the game
+                                    GameData.instance.game = it.data
+                                    view.setInfoLabel("A worthy opponent joined!")
+                                    view.setOpponentLabel("${it.data.opponent?.displayName}")
+                                    view.setOpponentBeardLengthLabel(
+                                        it.data.opponent?.beardLength ?: 0f
+                                    )
+                                    view.setStartGameBtnVisibility(true)
+                                } else {
+                                    view.setOpponentLabel("Waiting for opponent to join");
+                                    view.setInfoLabel(Nls.shareGameCodeMessage())
+                                    view.setStartGameBtnVisibility(false)
+                                }
+                            }
+                            is State.Loading -> {
+                            }
+                            is State.Failed -> {
+                                LOG.error { it.message }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fun dispose() {
+        if (subscription != null && subscription.isActive) {
+            subscription.cancel()
+        }
+        lobbyHandler.deleteObserver(this)
+    }
+}
+

--- a/core/src/main/kotlin/no/ntnu/beardblaster/lobby/LobbyScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/lobby/LobbyScreen.kt
@@ -5,57 +5,37 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch
 import com.badlogic.gdx.scenes.scene2d.ui.Button
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
 import ktx.actors.onClick
 import ktx.assets.async.AssetStorage
-import ktx.async.KtxAsync
-import ktx.log.debug
-import ktx.log.error
-import ktx.log.logger
 import ktx.scene2d.*
 import no.ntnu.beardblaster.BaseScreen
 import no.ntnu.beardblaster.BeardBlasterGame
 import no.ntnu.beardblaster.WORLD_WIDTH
 import no.ntnu.beardblaster.assets.Nls
-import no.ntnu.beardblaster.commons.State
-import no.ntnu.beardblaster.commons.game.Game
-import no.ntnu.beardblaster.game.GameData
-import no.ntnu.beardblaster.game.GamePlayScreen
 import no.ntnu.beardblaster.leaderboard.BeardScale
-import no.ntnu.beardblaster.menu.MenuScreen
 import no.ntnu.beardblaster.ui.*
-import java.util.*
-
-private val LOG = logger<LobbyScreen>()
 
 class LobbyScreen(
     game: BeardBlasterGame,
     batch: SpriteBatch,
     assets: AssetStorage,
     camera: OrthographicCamera,
-) : BaseScreen(game, batch, assets, camera), Observer {
+) : BaseScreen(game, batch, assets, camera), LobbyPresenter.View {
+    private val presenter = LobbyPresenter(this, game)
     private lateinit var codeLabel: Label
     private lateinit var opponentLabel: Label
     private lateinit var opponentBeardLabel: Label
     private lateinit var infoLabel: Label
     private lateinit var startGameBtn: TextButton
     private lateinit var backBtn: Button
-    private lateinit var subscription: Job
-    private var lobbyHandler: LobbyHandler = LobbyHandler()
 
     override fun initScreen() {
-        lobbyHandler.addObserver(this)
         codeLabel = bodyLabel("Creating game..", 1.5f, LabelStyle.BodyOutlined.name)
         opponentLabel = bodyLabel("Waiting for opponent to join..", 1.5f, LabelStyle.Body.name)
         opponentBeardLabel = bodyLabel("", 1.5f, LabelStyle.Body.name)
 
-        KtxAsync.launch {
-            lobbyHandler.createLobby()
-        }
+        presenter.init()
 
         infoLabel = scene2d.label(Nls.shareGameCodeMessage())
         startGameBtn = scene2d.textButton(Nls.startGame())
@@ -94,106 +74,36 @@ class LobbyScreen(
     @InternalCoroutinesApi
     override fun setBtnEventListeners() {
         startGameBtn.onClick {
-            KtxAsync.launch {
-                lobbyHandler.startGame()?.collect {
-                    when (it) {
-                        is State.Loading -> {
-                            opponentLabel.setText("Starting game..")
-                        }
-                        is State.Failed -> {
-                            opponentLabel.setText(it.message)
-                            LOG.error { it.message }
-                        }
-                        is State.Success -> {
-                            game.setScreen<GamePlayScreen>()
-                        }
-                    }
-                }
-            }
+            presenter.onStartGameBtnClick()
         }
         backBtn.onClick {
-            KtxAsync.launch {
-                if (lobbyHandler.game == null) {
-                    game.setScreen<MenuScreen>()
-                } else {
-                    lobbyHandler.cancelLobby()?.collect {
-                        when (it) {
-                            is State.Success -> {
-                                lobbyHandler.setGame(null)
-                                GameData.instance.game = null
-                                dispose()
-                                game.setScreen<MenuScreen>()
-                            }
-                            is State.Loading -> {
-
-                            }
-                            is State.Failed -> {
-                                LOG.error { it.message }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    override fun update(delta: Float) {}
-
-    @ExperimentalCoroutinesApi
-    override fun update(o: Observable?, arg: Any?) {
-        if (arg is Game) {
-            codeLabel.setText(arg.code)
-
-            LOG.debug { "Game created - Subscribing to new game." }
-            LOG.debug { "Should I subscribe? ${!::subscription.isInitialized || !subscription.isActive}." }
-            LOG.debug { "Is initialized? ${::subscription.isInitialized}." }
-            LOG.debug { "Is active? ${::subscription.isInitialized && subscription.isActive}." }
-
-            if(::subscription.isInitialized && subscription.isActive) {
-                subscription.cancel()
-            }
-
-
-            if(!::subscription.isInitialized || !subscription.isActive) {
-                // Yeah, this is ugly! Listen for live updates on lobby with id
-                subscription = KtxAsync.launch {
-                    LOG.debug { "Running subscribe to game with id ${arg.id}" }
-
-                    LobbyRepository().subscribeToLobbyUpdates(arg.id).collect {
-                        when (it) {
-                            is State.Success -> {
-                                // On received update: Check if opponent of updated Game is not null
-                                if (it.data.opponent != null) {
-                                    // Player may now start the game
-                                    GameData.instance.game = it.data
-                                    infoLabel.setText("A worthy opponent joined!")
-                                    opponentLabel.setText("${it.data.opponent?.displayName}")
-                                    opponentBeardLabel.setText("${it.data.opponent?.beardLength}cm")
-                                    opponentBeardLabel.color = BeardScale.getBeardColor(it.data.opponent?.beardLength?:0f)
-                                    startGameBtn.isVisible = true
-                                } else {
-                                    opponentLabel.setText("Waiting for opponent to join");
-                                    infoLabel.setText(Nls.shareGameCodeMessage())
-                                    startGameBtn.isVisible = false
-                                }
-                            }
-                            is State.Loading -> {
-                            }
-                            is State.Failed -> {
-                                LOG.error { it.message }
-                            }
-                        }
-                    }
-                }
-            }
+            presenter.onBackBtnClick()
         }
     }
 
     override fun dispose() {
         super.dispose()
-        if(subscription != null && subscription.isActive) {
-            subscription.cancel()
-        }
-        lobbyHandler.deleteObserver(this)
+        presenter.dispose()
+    }
+
+    override fun setInfoLabel(string: String) {
+        infoLabel.setText(string)
+    }
+
+    override fun setCodeLabel(code: String) {
+        codeLabel.setText(code)
+    }
+
+    override fun setOpponentLabel(string: String) {
+        opponentLabel.setText(string)
+    }
+
+    override fun setOpponentBeardLengthLabel(beardLength: Float) {
+        opponentBeardLabel.setText("${beardLength}cm")
+        opponentBeardLabel.color = BeardScale.getBeardColor(beardLength)
+    }
+
+    override fun setStartGameBtnVisibility(isVisible: Boolean) {
+        startGameBtn.isVisible = isVisible
     }
 }

--- a/core/src/main/kotlin/no/ntnu/beardblaster/lobby/LobbyScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/lobby/LobbyScreen.kt
@@ -24,7 +24,7 @@ import no.ntnu.beardblaster.assets.Nls
 import no.ntnu.beardblaster.commons.State
 import no.ntnu.beardblaster.commons.game.Game
 import no.ntnu.beardblaster.game.GameData
-import no.ntnu.beardblaster.game.GameplayScreen
+import no.ntnu.beardblaster.game.GamePlayScreen
 import no.ntnu.beardblaster.leaderboard.BeardScale
 import no.ntnu.beardblaster.menu.MenuScreen
 import no.ntnu.beardblaster.ui.*
@@ -105,7 +105,7 @@ class LobbyScreen(
                             LOG.error { it.message }
                         }
                         is State.Success -> {
-                            game.setScreen<GameplayScreen>()
+                            game.setScreen<GamePlayScreen>()
                         }
                     }
                 }

--- a/core/src/main/kotlin/no/ntnu/beardblaster/menu/LoginMenuPresenter.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/menu/LoginMenuPresenter.kt
@@ -1,0 +1,69 @@
+package no.ntnu.beardblaster.menu
+
+import com.badlogic.gdx.Gdx
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import ktx.async.KtxAsync
+import ktx.log.debug
+import ktx.log.error
+import ktx.log.info
+import ktx.log.logger
+import no.ntnu.beardblaster.BeardBlasterGame
+import no.ntnu.beardblaster.commons.State
+import no.ntnu.beardblaster.commons.user.User
+import no.ntnu.beardblaster.user.UserAuth
+import no.ntnu.beardblaster.user.UserRepository
+import pl.mk5.gdx.fireapp.auth.GdxFirebaseUser
+
+private val LOG = logger<LoginMenuPresenter>()
+
+class LoginMenuPresenter(private val view: View, val game: BeardBlasterGame) {
+
+    interface View {
+        fun setErrorLabel(msg: String)
+    }
+
+    fun onLoginClick(isValid: Boolean, email: String, password: String) {
+        if (!UserAuth().isLoggedIn() && isValid) {
+            UserAuth().signIn(email, password)
+                .then<GdxFirebaseUser> {
+                    Gdx.app.postRunnable { game.setScreen<MenuScreen>() }
+                }
+                .fail { message, _ ->
+                    LOG.error { message }
+                    view.setErrorLabel(message)
+                }
+        }
+    }
+
+    fun onRegisterClick(username: String, email: String, password: String) {
+        LOG.debug { "Creating new user: ($username, $email, $password)" }
+        UserAuth().createUser(email, password, username)
+            .then<GdxFirebaseUser> {
+                val user = User(username, id = it.userInfo.uid)
+                KtxAsync.launch {
+                    UserRepository().create(user, "users").collect { state: State<User> ->
+                        when (state) {
+                            is State.Success -> {
+                                game.setScreen<MenuScreen>()
+                            }
+                            is State.Failed -> {
+                                LOG.error { state.message }
+                                view.setErrorLabel(state.message)
+                            }
+                            is State.Loading -> {
+                                LOG.info { "Creating user.." }
+                            }
+                        }
+                    }
+                }
+            }.fail { message, _ ->
+                LOG.error { message }
+                view.setErrorLabel(message)
+            }
+    }
+
+    fun onExitBtnClick() {
+        Gdx.app.exit()
+    }
+}

--- a/core/src/main/kotlin/no/ntnu/beardblaster/menu/LoginMenuScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/menu/LoginMenuScreen.kt
@@ -1,41 +1,27 @@
 package no.ntnu.beardblaster.menu
 
-import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.OrthographicCamera
 import com.badlogic.gdx.graphics.g2d.SpriteBatch
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
 import ktx.actors.onChange
 import ktx.actors.onClick
 import ktx.assets.async.AssetStorage
-import ktx.async.KtxAsync
-import ktx.log.debug
-import ktx.log.error
-import ktx.log.info
-import ktx.log.logger
 import ktx.scene2d.scene2d
 import ktx.scene2d.textButton
 import no.ntnu.beardblaster.BaseScreen
 import no.ntnu.beardblaster.BeardBlasterGame
 import no.ntnu.beardblaster.assets.Nls
-import no.ntnu.beardblaster.commons.State
-import no.ntnu.beardblaster.commons.user.User
 import no.ntnu.beardblaster.ui.*
 import no.ntnu.beardblaster.user.LoginDialog
 import no.ntnu.beardblaster.user.RegisterDialog
-import no.ntnu.beardblaster.user.UserAuth
-import no.ntnu.beardblaster.user.UserRepository
-import pl.mk5.gdx.fireapp.auth.GdxFirebaseUser
-
-private val LOG = logger<LoginMenuScreen>()
 
 class LoginMenuScreen(
     game: BeardBlasterGame,
     batch: SpriteBatch,
     assets: AssetStorage,
     camera: OrthographicCamera
-) : BaseScreen(game, batch, assets, camera) {
+) : BaseScreen(game, batch, assets, camera), LoginMenuPresenter.View {
+    private val presenter = LoginMenuPresenter(this, game)
     private lateinit var exitBtn: TextButton
     private lateinit var loginBtn: TextButton
     private lateinit var registerBtn: TextButton
@@ -64,24 +50,13 @@ class LoginMenuScreen(
     override fun setBtnEventListeners() {
         loginBtn.onClick { showLoginDialog() }
         registerBtn.onClick { showRegisterDialog() }
-        exitBtn.onClick { Gdx.app.exit() }
+        exitBtn.onClick { presenter.onExitBtnClick() }
     }
-
-    override fun update(delta: Float) {}
 
     private fun showLoginDialog() {
         LoginDialog().apply {
             okBtn.onChange {
-                if (!UserAuth().isLoggedIn() && isValid) {
-                    UserAuth().signIn(email, password)
-                        .then<GdxFirebaseUser> {
-                            Gdx.app.postRunnable { game.setScreen<MenuScreen>() }
-                        }
-                        .fail { message, _ ->
-                            LOG.error { message }
-                            errorLabel.setText(message)
-                        }
-                }
+                presenter.onLoginClick(isValid, email, password)
             }
         }.show(stage)
     }
@@ -89,31 +64,12 @@ class LoginMenuScreen(
     private fun showRegisterDialog() {
         RegisterDialog().apply {
             okBtn.onChange {
-                LOG.debug { "Creating new user: ($username, $email, $password)" }
-                UserAuth().createUser(email, password, username)
-                    .then<GdxFirebaseUser> {
-                        val user = User(username, id = it.userInfo.uid)
-                        KtxAsync.launch {
-                            UserRepository().create(user, "users").collect { state: State<User> ->
-                                when (state) {
-                                    is State.Success -> {
-                                        game.setScreen<MenuScreen>()
-                                    }
-                                    is State.Failed -> {
-                                        LOG.error { state.message }
-                                        errorLabel.setText(state.message)
-                                    }
-                                    is State.Loading -> {
-                                        LOG.info { "Creating user.." }
-                                    }
-                                }
-                            }
-                        }
-                    }.fail { message, _ ->
-                        LOG.error { message }
-                        errorLabel.setText(message)
-                    }
+                presenter.onRegisterClick(username, email, password)
             }
         }.show(stage)
+    }
+
+    override fun setErrorLabel(msg: String) {
+        errorLabel.setText(msg)
     }
 }

--- a/core/src/main/kotlin/no/ntnu/beardblaster/menu/MenuScreen.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/menu/MenuScreen.kt
@@ -26,7 +26,7 @@ class MenuScreen(
     assets: AssetStorage,
     camera: OrthographicCamera,
 ) : BaseScreen(game, batch, assets, camera), MenuPresenter.View {
-    private val presenter: MenuPresenter = MenuPresenter(this, game)
+    private val presenter = MenuPresenter(this, game)
 
     private lateinit var createGameBtn: TextButton
     private lateinit var joinGameBtn: TextButton
@@ -123,9 +123,6 @@ class MenuScreen(
         exitBtn.onClick {
             presenter.onExitBtnClick()
         }
-    }
-
-    override fun update(delta: Float) {
     }
 
     override fun dispose() {

--- a/core/src/main/kotlin/no/ntnu/beardblaster/wizard/Animation.kt
+++ b/core/src/main/kotlin/no/ntnu/beardblaster/wizard/Animation.kt
@@ -3,9 +3,9 @@ package no.ntnu.beardblaster.wizard
 import com.badlogic.gdx.graphics.g2d.TextureRegion
 import com.badlogic.gdx.utils.Array
 import ktx.log.logger
-import no.ntnu.beardblaster.game.GameplayScreen
+import no.ntnu.beardblaster.game.GamePlayScreen
 
-private val log = logger<GameplayScreen>()
+private val log = logger<GamePlayScreen>()
 class Animation {
     private var frames: Array<TextureRegion>? = Array()
     private var maxFrameTime: Float


### PR DESCRIPTION
I think there is nothing to gain from using the MVP pattern on the gameplay screen and tutorial screen. The tutorial screen is static with not much functionality anyway, and the gameplay screen is wayy too complicated to be any point in trying now.